### PR TITLE
Added safety check for creation_time

### DIFF
--- a/android/src/main/java/com/mybigday/rnmediameta/RNMediaMeta.java
+++ b/android/src/main/java/com/mybigday/rnmediameta/RNMediaMeta.java
@@ -110,7 +110,11 @@ public class RNMediaMeta extends ReactContextBaseJavaModule {
       }
 
       // Legacy support & camelCase
-      result.putString("createTime", result.getString("creation_time"));
+      // Only get the createTime if it exists.
+      // Otherwise an exception is thrown and thumb is never generated
+      if (result.hasKey("createTime")) {
+        result.putString("createTime", result.getString("creation_time"));
+      }
 
       if (options.getBoolean("getThumb")) {
         // get thumb


### PR DESCRIPTION
Accessing `creation_time` when it doesn't exist will throw an exception and it will cause the thumbnail to be never generated. Added a simple if condition to make sure it doesn't throw an exception.

Fixes #13 
  